### PR TITLE
Fix Travis Build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    jdk: oraclejdk8
+    jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+sudo: false
 language: java
 jdk:
   - oraclejdk8
@@ -22,7 +21,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: <enter your encrypted GitHub access token>
+    secure: VPPvEekibGYSb/Jh8C99NSBCZuOMiuKGor5qUBhy2KYIUbteQz8Xuil2t/64YUtzBJfd7kGdNDT3pXP6v8qVts0gIroJzGL1e/rbLPQF8vBRmc5iOWNhb9zrrMIY6puNa6bpht+URxFAUJBKp8UmmOPTyfy2TOkDGSPQntorMZ0=
   file:
     - "${RELEASE_PKG_FILE}"
     - "${RELEASE_DEB_FILE}"


### PR DESCRIPTION
Made the following changes:

- Don't specify distro, so it uses Ubuntu Xenial by default
- Switch from oraclejdk to openjdk, since oraclejdk install is broken
  - https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8
- put encrypted api key back in so release deploy works
- remove sudo (shouldn't be required)
