### PR TITLE
Fix a fragile JUnit which would only succeed when run in UTC-6 TZ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-sudo: required
-dist: trusty
+sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 addons:
   apt:
     packages:
@@ -22,7 +21,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: <enter your encrypted GitHub access token>
+    secure: VPPvEekibGYSb/Jh8C99NSBCZuOMiuKGor5qUBhy2KYIUbteQz8Xuil2t/64YUtzBJfd7kGdNDT3pXP6v8qVts0gIroJzGL1e/rbLPQF8vBRmc5iOWNhb9zrrMIY6puNa6bpht+URxFAUJBKp8UmmOPTyfy2TOkDGSPQntorMZ0=
   file:
     - "${RELEASE_PKG_FILE}"
     - "${RELEASE_DEB_FILE}"
@@ -30,4 +29,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    jdk: oraclejdk8
+    jdk: openjdk8

--- a/src/test/java/org/graylog/plugins/pagerduty/client/MessageFactoryTest.java
+++ b/src/test/java/org/graylog/plugins/pagerduty/client/MessageFactoryTest.java
@@ -51,6 +51,7 @@ public class MessageFactoryTest {
     private static final String TEST_STREAM_TITLE = "Test Stream Title";
     private static final String CLIENT_URL = "https://test";
     private static final String STREAM_ID = "0001";
+    private static final String TEST_TIMESTAMP = new DateTime(1).toString();
 
     @Mock
     private StreamService streamServiceMock;
@@ -131,7 +132,7 @@ public class MessageFactoryTest {
             + "severity=critical, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -166,7 +167,7 @@ public class MessageFactoryTest {
             + "severity=warning, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -201,7 +202,7 @@ public class MessageFactoryTest {
             + "severity=info, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -236,7 +237,7 @@ public class MessageFactoryTest {
             + "severity=info, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -271,7 +272,7 @@ public class MessageFactoryTest {
             + "severity=info, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -303,7 +304,7 @@ public class MessageFactoryTest {
             + "severity=critical, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }
@@ -333,7 +334,7 @@ public class MessageFactoryTest {
             + "severity=critical, "
             + "component=GraylogAlerts, source=Graylog:[], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[]}",
             result.getPayload().toString());
     }
@@ -369,7 +370,7 @@ public class MessageFactoryTest {
             + "severity=info, "
             + "component=GraylogAlerts, source=Graylog:[0001], "
             + "class=alerts, "
-            + "timestamp=1969-12-31T18:00:00.001-06:00, "
+            + "timestamp=" + TEST_TIMESTAMP + ", "
             + "group=[0001]}",
             result.getPayload().toString());
     }


### PR DESCRIPTION
The MessageFactoryTest JUnit was attempting to match on hard-coded local timestamp strings whereas the code generates timestamps based on the local timezone.  This caused the JUnit to fail when not run in the UTC-6 timezone.